### PR TITLE
Fix a bug for BGP Open Message

### DIFF
--- a/beka/bgp_message.py
+++ b/beka/bgp_message.py
@@ -80,9 +80,9 @@ def parse_capabilities(serialised_capabilities):
         if len(serialised_header) == 0:
             break
         capability_code, capability_length = struct.unpack("!BB", serialised_header)
+        serialised_capability = stream.read(capability_length)
         if capability_code in capability_keys:
             capability_key = capability_keys[capability_code]
-            serialised_capability = stream.read(capability_length)
             if capability_key not in capabilities:
                 capabilities[capability_key] = []
             capabilities[capability_key].append(capability_parsers[capability_code](serialised_capability))


### PR DESCRIPTION
While tried with FRR with faucet for BGP, it runns into problem
while parsing BGP capability in OPEN msg, the while loop cannot
break correctly.

this happens when the capability_code is not in capability_keys,
and the capability_length is not 0, the second while loop will read
data from stream, but it should not.

Signed-off-by: Yong Xu <yong.xu@corigine.com>