### PR TITLE
Require eventlet v0.33.3 which works with modern dnspython.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
-# dnspython 2.3.0 is not compatible with eventlet
-# https://github.com/eventlet/eventlet/issues/781
-dnspython<2.3.0
-eventlet>=0.26.1
+eventlet>=0.33.3
 pbr>=1.9


### PR DESCRIPTION
fixes #166